### PR TITLE
chore: release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,9 +84,3 @@ jobs:
       run: cargo clippy --target=wasm32-unknown-unknown -pcardinal-gui
     - name: Build
       run: cargo build --target=wasm32-unknown-unknown -pcardinal-gui
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Check format
-      run: cargo fmt -- --check || exit 1

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install ALSA development libraries
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /*.s
 cardinal-gui/dist
+run_report.md
+.bacon-locations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,8 +338,8 @@ name = "cardinal-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cardinal-uxn",
- "cardinal-varvara",
+ "cardinal-uxn 0.2.0",
+ "cardinal-varvara 0.2.0",
  "clap",
  "env_logger",
  "log",
@@ -350,8 +350,8 @@ name = "cardinal-gui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cardinal-uxn",
- "cardinal-varvara",
+ "cardinal-uxn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-varvara 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "cpal",
  "eframe",
@@ -363,18 +363,40 @@ dependencies = [
 
 [[package]]
 name = "cardinal-uxn"
-version = "0.1.0"
+version = "0.2.0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "cardinal-uxn"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1a6e3dee0c54ab7683d05aec36f6eed90ebe8363a43ccf377b0cb7dc02074c"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "cardinal-varvara"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "cardinal-uxn",
+ "cardinal-uxn 0.2.0",
  "chrono",
  "image 0.25.5",
+ "log",
+ "static_assertions",
+ "zerocopy",
+]
+
+[[package]]
+name = "cardinal-varvara"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2f320064600e974cfbab70403bc64a6e9a84d38f512c2fa454674f6611e6b"
+dependencies = [
+ "cardinal-uxn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "log",
  "static_assertions",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cardinal-uxn 0.2.0",
- "cardinal-varvara 0.2.0",
+ "cardinal-varvara 0.3.0",
  "clap",
  "env_logger",
  "log",
@@ -351,7 +351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cardinal-uxn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cardinal-varvara 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-varvara 0.2.0",
  "clap",
  "cpal",
  "eframe",
@@ -380,10 +380,11 @@ dependencies = [
 [[package]]
 name = "cardinal-varvara"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd2f320064600e974cfbab70403bc64a6e9a84d38f512c2fa454674f6611e6b"
 dependencies = [
- "cardinal-uxn 0.2.0",
+ "cardinal-uxn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
- "image 0.25.5",
  "log",
  "static_assertions",
  "zerocopy",
@@ -391,12 +392,11 @@ dependencies = [
 
 [[package]]
 name = "cardinal-varvara"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2f320064600e974cfbab70403bc64a6e9a84d38f512c2fa454674f6611e6b"
+version = "0.3.0"
 dependencies = [
- "cardinal-uxn 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-uxn 0.2.0",
  "chrono",
+ "image 0.25.5",
  "log",
  "static_assertions",
  "zerocopy",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ trunk build --release --public-url=/projects/cardinal/demo/ # edit this path
 
 July 2025 Changes
 - stdout and stderr callbacks
+- feat(audio): support dynamic sample rate selection between 48000 and 44100 Hz
 
 © 2024-2025 Matthew Keeter, David Horner
 Released under the [Mozilla Public License 2.0](/LICENSE.txt)

--- a/cardinal-gui/CHANGELOG.md
+++ b/cardinal-gui/CHANGELOG.md
@@ -7,16 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0](https://github.com/davehorner/cardinal/compare/cardinal-uxn-v0.1.0...cardinal-uxn-v0.2.0) - 2025-07-26
+## [0.1.0](https://github.com/davehorner/cardinal/releases/tag/cardinal-gui-v0.1.0) - 2025-07-26
 
 ### Added
 
 - *(audio)* [**breaking**] support dynamic sample rate selection between 48000 and 44100 Hz
 
-## [0.1.0](https://github.com/davehorner/cardinal/releases/tag/cardinal-uxn-v0.1.0) - 2025-07-25
-
 ### Other
 
+- add Release-plz GitHub Actions workflow configuration
 - rename raven project to cardinal and update related dependencies and documentation
 - Add notes on building the web GUI ([#19](https://github.com/davehorner/cardinal/pull/19))
 - Add fuzzing, fix things that were discovered ([#13](https://github.com/davehorner/cardinal/pull/13))

--- a/cardinal-gui/Cargo.toml
+++ b/cardinal-gui/Cargo.toml
@@ -2,11 +2,12 @@
 name = "cardinal-gui"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"
 description = "Simple GUI for a Uxn + Varvara system"
 authors = ["David Horner", "Matt Keeter <matt.j.keeter@gmail.com>"]
 readme = "../README.md"
-publish = false
+publish = true
 
 [dependencies]
 anyhow.workspace = true
@@ -14,7 +15,7 @@ eframe.workspace = true
 env_logger.workspace = true
 log.workspace = true
 
-varvara = { path = "../cardinal-varvara", package = "cardinal-varvara" }
+varvara = { package = "cardinal-varvara", version = "0.2.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap.workspace = true
@@ -26,7 +27,9 @@ web-sys.workspace = true
 cpal = { workspace = true, features = ["wasm-bindgen"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-uxn = { path = "../cardinal-uxn", package = "cardinal-uxn", features = ["native"] }
+uxn = { package = "cardinal-uxn", version = "0.2.0", features = [
+  "native",
+] }
 
 [target.'cfg(not(target_arch = "aarch64"))'.dependencies]
-uxn = { path = "../cardinal-uxn", package = "cardinal-uxn" }
+uxn = { package = "cardinal-uxn", version = "0.2.0" }

--- a/cardinal-uxn/Cargo.toml
+++ b/cardinal-uxn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinal-uxn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"

--- a/cardinal-varvara/CHANGELOG.md
+++ b/cardinal-varvara/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.2.0...cardinal-varvara-v0.3.0) - 2025-07-26
+
+### Added
+
+- *(audio)* [**breaking**] support dynamic sample rate selection between 48000 and 44100 Hz
+
 ## [0.2.0](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.1.0...cardinal-varvara-v0.2.0) - 2025-07-26
 
 ### Added

--- a/cardinal-varvara/CHANGELOG.md
+++ b/cardinal-varvara/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.1.0...cardinal-varvara-v0.2.0) - 2025-07-26
+
+### Added
+
+- *(audio)* [**breaking**] support dynamic sample rate selection between 48000 and 44100 Hz
+
 ## [0.1.0](https://github.com/davehorner/cardinal/releases/tag/cardinal-varvara-v0.1.0) - 2025-07-25
 
 ### Other

--- a/cardinal-varvara/Cargo.toml
+++ b/cardinal-varvara/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinal-varvara"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"

--- a/cardinal-varvara/Cargo.toml
+++ b/cardinal-varvara/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinal-varvara"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"
@@ -14,7 +14,7 @@ log.workspace = true
 static_assertions.workspace = true
 zerocopy.workspace = true
 
-uxn = { path = "../cardinal-uxn", package = "cardinal-uxn", version = "0.1" }
+uxn = { path = "../cardinal-uxn", package = "cardinal-uxn", version = "0.2" }
 
 [dev-dependencies]
 image.workspace = true

--- a/cardinal-varvara/src/lib.rs
+++ b/cardinal-varvara/src/lib.rs
@@ -19,8 +19,7 @@ mod audio;
 
 pub use audio::StreamData;
 pub use audio::CHANNELS as AUDIO_CHANNELS;
-pub use audio::SAMPLE_RATE as AUDIO_SAMPLE_RATE;
-
+pub use audio::set_sample_rate;
 pub use controller::Key;
 pub use mouse::MouseState;
 


### PR DESCRIPTION



## 🤖 New release

* `cardinal-varvara`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `cardinal-gui`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `cardinal-varvara`

<blockquote>

## [0.3.0](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.2.0...cardinal-varvara-v0.3.0) - 2025-07-26

### Added

- *(audio)* [**breaking**] support dynamic sample rate selection between 48000 and 44100 Hz
</blockquote>

## `cardinal-gui`

<blockquote>

## [0.1.0](https://github.com/davehorner/cardinal/releases/tag/cardinal-gui-v0.1.0) - 2025-07-26

### Added

- *(audio)* [**breaking**] support dynamic sample rate selection between 48000 and 44100 Hz

### Other

- add Release-plz GitHub Actions workflow configuration
- rename raven project to cardinal and update related dependencies and documentation
- Add notes on building the web GUI ([#19](https://github.com/davehorner/cardinal/pull/19))
- Add fuzzing, fix things that were discovered ([#13](https://github.com/davehorner/cardinal/pull/13))
- tweak text
- Add license and stuff
- Updating README to link to project page
- Update README
- Make README more accurate
- Fix directory listing in Potato
- More README updates
- Implement arguments
- Update implementation notes
- Remove GUI loop from Varvara crate (!)
- Make Varvara audio implementation-agnostic
- use to/from_le_bytes instead
- Working aroud bad codegen
- Staring at assembly
- Begin updating README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).