### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,8 +416,8 @@ name = "cardinal-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cardinal-uxn 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cardinal-varvara 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-uxn 0.4.4",
+ "cardinal-varvara 0.4.8",
  "clap",
  "env_logger",
  "log",
@@ -428,8 +428,8 @@ name = "cardinal-gui"
 version = "0.3.9"
 dependencies = [
  "anyhow",
- "cardinal-uxn 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cardinal-varvara 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-uxn 0.4.4",
+ "cardinal-varvara 0.4.8",
  "clap",
  "cpal",
  "display-info",
@@ -456,14 +456,6 @@ dependencies = [
 [[package]]
 name = "cardinal-uxn"
 version = "0.4.4"
-dependencies = [
- "anyhow",
- "zerocopy",
-]
-
-[[package]]
-name = "cardinal-uxn"
-version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fab4aeba76650089ab905c7b8af15a9e751149efe56a58cae4521750e84c1d8"
 dependencies = [
@@ -472,16 +464,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cardinal-varvara"
-version = "0.4.8"
+name = "cardinal-uxn"
+version = "0.4.5"
 dependencies = [
- "cardinal-uxn 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono",
- "gilrs",
- "hidapi",
- "image",
- "log",
- "static_assertions",
+ "anyhow",
  "zerocopy",
 ]
 
@@ -491,10 +477,24 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c716be62d616902feb667b62d9cbde2eb471c3fbc4fcf67f03ccbda2fcf370"
 dependencies = [
- "cardinal-uxn 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cardinal-uxn 0.4.4",
  "chrono",
  "gilrs",
  "hidapi",
+ "log",
+ "static_assertions",
+ "zerocopy",
+]
+
+[[package]]
+name = "cardinal-varvara"
+version = "0.4.9"
+dependencies = [
+ "cardinal-uxn 0.4.4",
+ "chrono",
+ "gilrs",
+ "hidapi",
+ "image",
  "log",
  "static_assertions",
  "zerocopy",

--- a/cardinal-uxn/CHANGELOG.md
+++ b/cardinal-uxn/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/davehorner/cardinal/compare/cardinal-uxn-v0.4.4...cardinal-uxn-v0.4.5) - 2025-07-31
+
+### Other
+
+- *(gui+build)* add e_midi support and aarch64 cross-compilation via Docker  - Enabled `uses_e_midi` feature in `cardinal-demo` (enabled by default). - Added `e_midi.rs` module with MidiPlayerThread lifecycle management. - Cleanly shuts down MIDI thread on GUI close via `AppWithClose` wrapper.  NOT TRUE - CTRL+C to EXIT.  TODO. - Reduced USB controller logging noise for cleaner output. - Added `Dockerfile.aarch64` and Windows `build_aarch64.cmd` to support   cross-compilation of cardinal-orcas for `aarch64-unknown-linux-gnu`.
+
 ## [0.4.4](https://github.com/davehorner/cardinal/compare/cardinal-uxn-v0.4.3...cardinal-uxn-v0.4.4) - 2025-07-30
 
 ### Added

--- a/cardinal-uxn/Cargo.toml
+++ b/cardinal-uxn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinal-uxn"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"

--- a/cardinal-varvara/CHANGELOG.md
+++ b/cardinal-varvara/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.4.8...cardinal-varvara-v0.4.9) - 2025-07-31
+
+### Other
+
+- *(gui+build)* add e_midi support and aarch64 cross-compilation via Docker  - Enabled `uses_e_midi` feature in `cardinal-demo` (enabled by default). - Added `e_midi.rs` module with MidiPlayerThread lifecycle management. - Cleanly shuts down MIDI thread on GUI close via `AppWithClose` wrapper.  NOT TRUE - CTRL+C to EXIT.  TODO. - Reduced USB controller logging noise for cleaner output. - Added `Dockerfile.aarch64` and Windows `build_aarch64.cmd` to support   cross-compilation of cardinal-orcas for `aarch64-unknown-linux-gnu`.
+
 ## [0.4.8](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.4.7...cardinal-varvara-v0.4.8) - 2025-07-31
 
 ### Added

--- a/cardinal-varvara/Cargo.toml
+++ b/cardinal-varvara/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardinal-varvara"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/davehorner/cardinal"


### PR DESCRIPTION



## 🤖 New release

* `cardinal-uxn`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `cardinal-varvara`: 0.4.8 -> 0.4.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cardinal-uxn`

<blockquote>

## [0.4.5](https://github.com/davehorner/cardinal/compare/cardinal-uxn-v0.4.4...cardinal-uxn-v0.4.5) - 2025-07-31

### Other

- *(gui+build)* add e_midi support and aarch64 cross-compilation via Docker  - Enabled `uses_e_midi` feature in `cardinal-demo` (enabled by default). - Added `e_midi.rs` module with MidiPlayerThread lifecycle management. - Cleanly shuts down MIDI thread on GUI close via `AppWithClose` wrapper.  NOT TRUE - CTRL+C to EXIT.  TODO. - Reduced USB controller logging noise for cleaner output. - Added `Dockerfile.aarch64` and Windows `build_aarch64.cmd` to support   cross-compilation of cardinal-orcas for `aarch64-unknown-linux-gnu`.
</blockquote>

## `cardinal-varvara`

<blockquote>

## [0.4.9](https://github.com/davehorner/cardinal/compare/cardinal-varvara-v0.4.8...cardinal-varvara-v0.4.9) - 2025-07-31

### Other

- *(gui+build)* add e_midi support and aarch64 cross-compilation via Docker  - Enabled `uses_e_midi` feature in `cardinal-demo` (enabled by default). - Added `e_midi.rs` module with MidiPlayerThread lifecycle management. - Cleanly shuts down MIDI thread on GUI close via `AppWithClose` wrapper.  NOT TRUE - CTRL+C to EXIT.  TODO. - Reduced USB controller logging noise for cleaner output. - Added `Dockerfile.aarch64` and Windows `build_aarch64.cmd` to support   cross-compilation of cardinal-orcas for `aarch64-unknown-linux-gnu`.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).