### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "uxn-tal"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5220,7 +5220,7 @@ dependencies = [
  "thiserror 2.0.17",
  "url",
  "uxn-tal-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "uxn-tal-defined 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uxn-tal-defined 0.2.0",
  "walkdir",
  "which 8.0.0",
  "winapi",
@@ -5246,19 +5246,19 @@ dependencies = [
 [[package]]
 name = "uxn-tal-defined"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da052aaa1cb26bb3bbc21d5cfa7abfd28ee7c58c2a7e6a0453ac94077927bcd4"
 dependencies = [
- "tempfile",
- "tiny_http",
  "uxn-tal-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 8.0.0",
 ]
 
 [[package]]
 name = "uxn-tal-defined"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da052aaa1cb26bb3bbc21d5cfa7abfd28ee7c58c2a7e6a0453ac94077927bcd4"
+version = "0.2.1"
 dependencies = [
+ "tempfile",
+ "tiny_http",
  "uxn-tal-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 8.0.0",
 ]

--- a/cardinal-cli/Cargo.toml
+++ b/cardinal-cli/Cargo.toml
@@ -13,7 +13,7 @@ anyhow.workspace = true
 clap.workspace = true
 env_logger.workspace = true
 log.workspace = true
-uxn-tal = { version = "0.6.0", path = "../uxn-tal" }
+uxn-tal = { version = "0.6.2", path = "../uxn-tal" }
 
 varvara = { package = "cardinal-varvara", version = "0.8.0" }
 

--- a/uxn-tal-defined/CHANGELOG.md
+++ b/uxn-tal-defined/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/davehorner/cardinal/compare/uxn-tal-defined-v0.2.0...uxn-tal-defined-v0.2.1) - 2025-11-02
+
+### Other
+
+- *(compatibility_matrix)* README updates and compatibility matrix.
+- *(orca)* fix to bootstrap orca.rom properly.
+
 ## [0.2.0](https://github.com/davehorner/cardinal/compare/uxn-tal-defined-v0.1.0...uxn-tal-defined-v0.2.0) - 2025-10-30
 
 ### Added

--- a/uxn-tal-defined/Cargo.toml
+++ b/uxn-tal-defined/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxn-tal-defined"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Shared protocol definitions for uxntal://"
 license = "MIT OR Apache-2.0"

--- a/uxn-tal/CHANGELOG.md
+++ b/uxn-tal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/davehorner/cardinal/compare/uxn-tal-v0.6.1...uxn-tal-v0.6.2) - 2025-11-02
+
+### Other
+
+- *(compatibility_matrix)* README updates and compatibility matrix.
+
 ## [0.6.1](https://github.com/davehorner/cardinal/compare/uxn-tal-v0.6.0...uxn-tal-v0.6.1) - 2025-10-30
 
 ### Fixed

--- a/uxn-tal/Cargo.toml
+++ b/uxn-tal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxn-tal"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["David Horner"]
 description = "uxntal:// protocol | a Rust library for assembling TAL (Tal Assembly Language) files into UXN ROM files"


### PR DESCRIPTION



## 🤖 New release

* `uxn-tal-defined`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `uxn-tal`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `uxn-tal-defined`

<blockquote>

## [0.2.1](https://github.com/davehorner/cardinal/compare/uxn-tal-defined-v0.2.0...uxn-tal-defined-v0.2.1) - 2025-11-02

### Other

- *(compatibility_matrix)* README updates and compatibility matrix.
- *(orca)* fix to bootstrap orca.rom properly.
</blockquote>

## `uxn-tal`

<blockquote>

## [0.6.2](https://github.com/davehorner/cardinal/compare/uxn-tal-v0.6.1...uxn-tal-v0.6.2) - 2025-11-02

### Other

- *(compatibility_matrix)* README updates and compatibility matrix.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).